### PR TITLE
adjusted opensearch for local ingesting in docker

### DIFF
--- a/utils/opensearch.py
+++ b/utils/opensearch.py
@@ -3,7 +3,13 @@ from dotenv import load_dotenv
 import certifi
 import boto3
 from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-from common.utils.secrets import get_secret
+
+try:
+    from common.utils.secrets import get_secret
+    print("[DEBUG] Using get_secret from common.utils")
+except ImportError:
+    from dp_ingest.utils.secrets import get_secret
+    print("[DEBUG] Using get_secret from dp_ingest.utils")
 
 '''
 This function creates an OpenSearch client. If the environment variables OPENSEARCH_HOST if OPENSEARCH_PORT are not
@@ -15,35 +21,42 @@ Outside of the function, interaction with the client is the same regardless of t
 '''
 def connect():
     load_dotenv()
+    env = os.getenv("ENVIRONMENT", "local").lower()
+    print(f"[DEBUG] ENVIRONMENT={env}")
 
-    secret_name = os.getenv('DB_SECRET_NAME')
+    if env == "local":
+        print("[DEBUG] Using local OpenSearch configuration")
+
+        host = os.getenv('OPENSEARCH_HOST', 'localhost')
+        port = int(os.getenv('OPENSEARCH_PORT', '9200'))
+        password = os.getenv('OPENSEARCH_INITIAL_ADMIN_PASSWORD')
+
+        if not password:
+            raise ValueError("Missing OPENSEARCH_INITIAL_ADMIN_PASSWORD in local .env")
+
+        auth = ('admin', password)
+
+        ca_certs_path = certifi.where()
+        client = OpenSearch(
+            hosts=[{'host': host, 'port': port}],
+            http_compress=True,
+            http_auth=auth,
+            use_ssl=False,
+            verify_certs=False,
+            ssl_assert_hostname=False,
+            ssl_show_warn=False,
+            ca_certs=ca_certs_path
+        )
+        return client
+
+    # Else: prod via AWS Secrets Manager
+    print("[DEBUG] Using AWS Secrets Manager configuration")
+    secret_name = os.getenv('OS_SECRET_NAME', 'mirrulationsdb/opensearch/master')
+    region = os.getenv('AWS_REGION', 'us-east-1')
     secret = get_secret(secret_name)
 
     host = secret['host']
     port = secret['port']
-    region = 'us-east-1'
-
-    if host is None or port is None:
-        raise ValueError('Please set the environment variables OPENSEARCH_HOST and OPENSEARCH_PORT')
-    
-    if host == 'localhost':
-        auth = ('admin', os.getenv('OPENSEARCH_INITIAL_ADMIN_PASSWORD'))
-
-        ca_certs_path = certifi.where()
-        # Create the client with SSL/TLS enabled, but hostname verification disabled.
-        client = OpenSearch(
-            hosts = [{'host': host, 'port': port}],
-            http_compress = True, # enables gzip compression for request bodies
-            http_auth = auth,
-            use_ssl = True,
-            verify_certs = False,
-            ssl_assert_hostname = False,
-            ssl_show_warn = False,
-            ca_certs = ca_certs_path
-        )
-
-        return client
-    
     service = 'aoss'
     credentials = boto3.Session().get_credentials()
     auth = AWSV4SignerAuth(credentials, region, service)


### PR DESCRIPTION
 Implemented logic in `opensearch.py` to detect and use `ENVIRONMENT=local` for local development.
- Fallback added for `get_secret` to support both `dp_ingest.utils` and `common.utils`.

Ingest Logic Updates (`utils/ingest_opensearch.py`)
- Fixed a `TypeError` caused by missing arguments when calling `ingest()`.
- Updated the following:
  - `ingest_comment()` now passes the required `id` and `index` to `ingest()`.
  - `ingest()` function now properly receives and logs `index` and `id`.
- Ensured both `ingest_all_comments()` and `ingest_all_extracted_text()` work as expected inside the Docker container:
  ```bash
  docker exec -it ingest-container bash -c "python -m dp_ingest.utils.ingest_opensearch"
  ```

# PLEASE LET THIS BE THE END 
![Skeleton](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmU2M3QyZ2k4bHhhdG00OHJteDdibWtlcHczbXRwem53aGNmaTBydyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/THlB4bsoSA0Cc/giphy.gif)