### PR TITLE
Separate date function

### DIFF
--- a/utils/date.py
+++ b/utils/date.py
@@ -1,7 +1,15 @@
 from datetime import datetime
 
 
-def parse_date(date_str):
-    if date_str:
-        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+# Function to parse date fields
+def parse(date: str):
+    if date:
+        if date.startswith(
+            "0000"
+        ):  # date can be 0000-12-30T00:00:00Z in certain cases, like postedDate in the comment CMS-2009-0058-DRAFT-2645
+            date = date.replace(
+                "0000", "2000"
+            )  # this is the behavior from regulations.gov's website,
+            # i believe this may be because the comment was withdrawn...
+        return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return None

--- a/utils/date.py
+++ b/utils/date.py
@@ -4,12 +4,9 @@ from datetime import datetime
 # Function to parse date fields
 def parse(date: str):
     if date:
-        if date.startswith(
-            "0000"
-        ):  # date can be 0000-12-30T00:00:00Z in certain cases, like postedDate in the comment CMS-2009-0058-DRAFT-2645
-            date = date.replace(
-                "0000", "2000"
-            )  # this is the behavior from regulations.gov's website,
-            # i believe this may be because the comment was withdrawn...
+        # date can be 0000-12-30T00:00:00Z in certain cases, like postedDate in the comment CMS-2009-0058-DRAFT-2645
+        if date.startswith("0000"):  
+            # this mimics the behavior from regulations.gov's website,
+            date = date.replace("0000", "2000")
         return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return None

--- a/utils/date.py
+++ b/utils/date.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+
+def parse_date(date_str):
+    if date_str:
+        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+    return None

--- a/utils/ingest_comment.py
+++ b/utils/ingest_comment.py
@@ -4,15 +4,7 @@ from dotenv import load_dotenv
 import sys
 import os
 from datetime import datetime
-
-# Fetch database connection parameters from environment variables
-
-
-# Function to parse date fields
-def parse_date(date_str):
-    if date_str:
-        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
-    return None
+from .date import parse as parse_date
 
 
 # Function to insert comment into the database

--- a/utils/ingest_docket.py
+++ b/utils/ingest_docket.py
@@ -3,16 +3,7 @@ import psycopg
 from dotenv import load_dotenv
 import sys
 import os
-from datetime import datetime
-
-# Fetch database connection parameters from environment variables
-
-
-# Function to parse date fields
-def _parse_date(date_str):
-    if date_str:
-        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
-    return None
+from .date import parse as parse_date
 
 
 # Function to insert docket into the database
@@ -32,10 +23,10 @@ def insert_docket(conn, json_data):
         attributes["agencyId"],
         attributes["category"],
         attributes["docketType"],
-        _parse_date(attributes["effectiveDate"]),
+        parse_date(attributes["effectiveDate"]),
         attributes["field1"],
         attributes["field2"],
-        _parse_date(attributes["modifyDate"]),
+        parse_date(attributes["modifyDate"]),
         attributes["organization"],
         attributes["petitionNbr"],
         attributes["program"],

--- a/utils/ingest_document.py
+++ b/utils/ingest_document.py
@@ -3,16 +3,7 @@ import psycopg
 from dotenv import load_dotenv
 import sys
 import os
-from datetime import datetime
-
-# Fetch database connection parameters from environment variables
-
-
-# Function to parse date fields
-def _parse_date(date_str):
-    if date_str:
-        return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
-    return None
+from .date import parse as parse_date
 
 
 # Function to insert document into the database
@@ -33,16 +24,16 @@ def insert_document(conn, json_data):
         attributes.get("address2"),
         attributes.get("agencyId"),
         attributes.get("allowLateComments"),
-        _parse_date(attributes.get("authorDate")),
+        parse_date(attributes.get("authorDate")),
         attributes.get("category"),
         attributes.get("city"),
         attributes.get("comment"),
-        _parse_date(attributes.get("commentEndDate")),
-        _parse_date(attributes.get("commentStartDate")),
+        parse_date(attributes.get("commentEndDate")),
+        parse_date(attributes.get("commentStartDate")),
         attributes.get("country"),
         attributes.get("docketId"),
         attributes.get("documentType"),
-        _parse_date(attributes.get("effectiveDate")),
+        parse_date(attributes.get("effectiveDate")),
         attributes.get("email"),
         attributes.get("fax"),
         attributes.get("field1"),
@@ -50,16 +41,16 @@ def insert_document(conn, json_data):
         attributes.get("firstName"),
         attributes.get("govAgency"),
         attributes.get("govAgencyType"),
-        _parse_date(attributes.get("implementationDate")),
+        parse_date(attributes.get("implementationDate")),
         attributes.get("lastName"),
-        _parse_date(attributes.get("modifyDate")),
+        parse_date(attributes.get("modifyDate")),
         attributes.get("openForComment"),
         attributes.get("organization"),
         attributes.get("phone"),
-        _parse_date(attributes.get("postedDate")),
-        _parse_date(attributes.get("postmarkDate")),
+        parse_date(attributes.get("postedDate")),
+        parse_date(attributes.get("postmarkDate")),
         attributes.get("reasonWithdrawn"),
-        _parse_date(attributes.get("receiveDate")),
+        parse_date(attributes.get("receiveDate")),
         attributes.get("regWriterInstruction"),
         attributes.get("restrictReason"),
         attributes.get("restrictReasonType"),


### PR DESCRIPTION
the same function was in all three of the ingest files, this PR separates it into its own file.
It also adds a check in case the year is `0000` in a date, and mimics the functionality seen on regulations.gov.