### PR TITLE
Change the field that is used as ID for attachments

### DIFF
--- a/utils/ingest_opensearch.py
+++ b/utils/ingest_opensearch.py
@@ -26,7 +26,7 @@ def ingest_extracted_text_from_text(client, data):
         'commentId': data['commentId'],
         'attachmentId': data['attachmentId']
     }
-    ingest(client, document, id = document['commentId'], index= 'extracted_text_test')
+    ingest(client, document, id = document['attachmentId'], index= 'extracted_text_test')
 
 
 def ingest_comment(client, bucket, key):


### PR DESCRIPTION
Currently, this function uses the commentId as the id field, but there could be multiple attachments on the same comment, so we should use attachmentId instead.