### PR TITLE
Create a dummy docket for documents without a docket

### DIFF
--- a/utils/dummy_docket.py
+++ b/utils/dummy_docket.py
@@ -1,0 +1,25 @@
+import re
+
+
+def get_docket_id(document_id: str):
+    # a regex that matches the last -xxxx of a document id
+    pattern = r"-\d+$"
+
+    return re.sub(pattern, "", document_id)
+
+
+def create(document: dict):
+    docket_id = document.get("docketId", get_docket_id(document.get("documentId")))
+    return {
+        "data": {
+            "id": docket_id,
+            "type": "dockets",
+            "attributes": {
+                "agencyId": document.get("agencyId"),
+                "docketType": f"Dummy ({document.get('documentType')})",  # as far as i know these can be any of the following: `Rule`, `Other`, and `Notice`
+                "modifyDate": document.get("modifyDate"),
+                "title": document.get("title"),
+            },
+            "links": {"self": f"https://api.regulations.gov/v4/dockets/{docket_id}"},
+        }
+    }

--- a/utils/dummy_docket.py
+++ b/utils/dummy_docket.py
@@ -8,17 +8,17 @@ def get_docket_id(document_id: str):
     return re.sub(pattern, "", document_id)
 
 
-def create(document: dict):
-    docket_id = document.get("docketId", get_docket_id(document.get("documentId")))
+def create(document_attributes: dict):
+    docket_id = document_attributes.get("docketId", get_docket_id(document_attributes.get("documentId")))
     return {
         "data": {
             "id": docket_id,
             "type": "dockets",
             "attributes": {
-                "agencyId": document.get("agencyId"),
-                "docketType": f"Dummy ({document.get('documentType')})",  # as far as i know these can be any of the following: `Rule`, `Other`, and `Notice`
-                "modifyDate": document.get("modifyDate"),
-                "title": document.get("title"),
+                "agencyId": document_attributes.get("agencyId"),
+                "docketType": f"Dummy ({document_attributes.get('documentType')})",  # as far as i know these can be any of the following: `Rule`, `Other`, and `Notice`
+                "modifyDate": document_attributes.get("modifyDate"),
+                "title": document_attributes.get("title"),
             },
             "links": {"self": f"https://api.regulations.gov/v4/dockets/{docket_id}"},
         }

--- a/utils/ingest_docket.py
+++ b/utils/ingest_docket.py
@@ -20,22 +20,23 @@ def insert_docket(conn, json_data):
     values = (
         docket_id,
         docket_api_link,
-        attributes["agencyId"],
-        attributes["category"],
-        attributes["docketType"],
-        parse_date(attributes["effectiveDate"]),
-        attributes["field1"],
-        attributes["field2"],
-        parse_date(attributes["modifyDate"]),
-        attributes["organization"],
-        attributes["petitionNbr"],
-        attributes["program"],
-        attributes["rin"],
-        attributes["shortTitle"],
-        attributes["subType"],
-        attributes["subType2"],
-        attributes["title"],
+        attributes.get("agencyId"),
+        attributes.get("category"),
+        attributes.get("docketType"),
+        parse_date(attributes.get("effectiveDate")),
+        attributes.get("field1"),
+        attributes.get("field2"),
+        parse_date(attributes.get("modifyDate")),
+        attributes.get("organization"),
+        attributes.get("petitionNbr"),
+        attributes.get("program"),
+        attributes.get("rin"),
+        attributes.get("shortTitle"),
+        attributes.get("subType"),
+        attributes.get("subType2"),
+        attributes.get("title"),
     )
+
 
     # Insert into the database
     try:

--- a/utils/ingest_document.py
+++ b/utils/ingest_document.py
@@ -4,6 +4,8 @@ from dotenv import load_dotenv
 import sys
 import os
 from .date import parse as parse_date
+from .dummy_docket import create as create_dummy_docket
+from .ingest_docket import insert_docket
 
 
 # Function to insert document into the database
@@ -15,6 +17,11 @@ def insert_document(conn, json_data):
     attributes = data["data"]["attributes"]
     document_id = data["data"]["id"]
     document_api_link = data["data"]["links"]["self"]
+
+    # if the docket is null, ingest a dummy docket
+    if attributes.get("docketId") is None:
+        docket = create_dummy_docket(attributes)
+        insert_docket(conn, docket)
 
     # Prepare the values for insertion
     values = (


### PR DESCRIPTION
Certain documents in regulations.gov do not have a docket attached to them, in order to ingest these into our relational database, we need to create a docket purely for the document to reference.

a few examples of documents are linked below:
- [ACFR-2014-0001-0002](https://www.regulations.gov/document/ACFR-2014-0001-0002)
- [AFRH-2009-0002-0001](https://www.regulations.gov/document/AFRH-2009-0002-0001)
- [CFTC-2007-0078-0001](https://www.regulations.gov/document/CFTC-2007-0078-0001)