### PR TITLE
Change ingest scripts to upsert rather than insert

### DIFF
--- a/utils/ingest_comment.py
+++ b/utils/ingest_comment.py
@@ -71,7 +71,43 @@ def insert_comment(conn, json_data):
                 comment_title, is_withdrawn, postal_code
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s);
+                    %s, %s, %s)
+            ON CONFLICT (comment_id) DO UPDATE
+            SET
+                api_link = EXCLUDED.api_link,
+                document_id = EXCLUDED.document_id,
+                duplicate_comment_count = EXCLUDED.duplicate_comment_count,
+                address1 = EXCLUDED.address1,
+                address2 = EXCLUDED.address2,
+                agency_id = EXCLUDED.agency_id,
+                city = EXCLUDED.city,
+                comment_category = EXCLUDED.comment_category,
+                comment = EXCLUDED.comment,
+                country = EXCLUDED.country,
+                docket_id = EXCLUDED.docket_id,
+                document_type = EXCLUDED.document_type,
+                email = EXCLUDED.email,
+                fax = EXCLUDED.fax,
+                flex_field1 = EXCLUDED.flex_field1,
+                flex_field2 = EXCLUDED.flex_field2,
+                first_name = EXCLUDED.first_name,
+                submitter_gov_agency = EXCLUDED.submitter_gov_agency,
+                submitter_gov_agency_type = EXCLUDED.submitter_gov_agency_type,
+                last_name = EXCLUDED.last_name,
+                modification_date = EXCLUDED.modification_date,
+                submitter_org = EXCLUDED.submitter_org,
+                phone = EXCLUDED.phone,
+                posted_date = EXCLUDED.posted_date,
+                postmark_date = EXCLUDED.postmark_date,
+                reason_withdrawn = EXCLUDED.reason_withdrawn,
+                received_date = EXCLUDED.received_date,
+                restriction_reason = EXCLUDED.restriction_reason,
+                restriction_reason_type = EXCLUDED.restriction_reason_type,
+                state_province_region = EXCLUDED.state_province_region,
+                comment_subtype = EXCLUDED.comment_subtype,
+                comment_title = EXCLUDED.comment_title,
+                is_withdrawn = EXCLUDED.is_withdrawn,
+                postal_code = EXCLUDED.postal_code;
             """
 
             cursor.execute(insert_query, values)

--- a/utils/ingest_docket.py
+++ b/utils/ingest_docket.py
@@ -47,7 +47,25 @@ def insert_docket(conn, json_data):
                 effective_date, flex_field1, flex_field2, modify_date, organization,
                 petition_nbr, program, rin, short_title, flex_subtype1, flex_subtype2,
                 docket_title
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (docket_id) DO UPDATE
+            SET
+                docket_api_link = EXCLUDED.docket_api_link,
+                agency_id = EXCLUDED.agency_id,
+                docket_category = EXCLUDED.docket_category,
+                docket_type = EXCLUDED.docket_type,
+                effective_date = EXCLUDED.effective_date,
+                flex_field1 = EXCLUDED.flex_field1,
+                flex_field2 = EXCLUDED.flex_field2,
+                modify_date = EXCLUDED.modify_date,
+                organization = EXCLUDED.organization,
+                petition_nbr = EXCLUDED.petition_nbr,
+                program = EXCLUDED.program,
+                rin = EXCLUDED.rin,
+                short_title = EXCLUDED.short_title,
+                flex_subtype1 = EXCLUDED.flex_subtype1,
+                flex_subtype2 = EXCLUDED.flex_subtype2,
+                docket_title = EXCLUDED.docket_title;
             """
             cursor.execute(insert_query, values)
             print(f"Docket {docket_id} inserted successfully.")

--- a/utils/ingest_document.py
+++ b/utils/ingest_document.py
@@ -84,7 +84,50 @@ def insert_document(conn, json_data):
                 receive_date, reg_writer_instruction, restriction_reason,
                 restriction_reason_type, state_province_region, subtype,
                 document_title, topics, is_withdrawn, postal_code
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (document_id) DO UPDATE
+            SET
+                document_api_link = EXCLUDED.document_api_link,
+                address1 = EXCLUDED.address1,
+                address2 = EXCLUDED.address2,
+                agency_id = EXCLUDED.agency_id,
+                is_late_comment = EXCLUDED.is_late_comment,
+                author_date = EXCLUDED.author_date,
+                comment_category = EXCLUDED.comment_category,
+                city = EXCLUDED.city,
+                comment = EXCLUDED.comment,
+                comment_end_date = EXCLUDED.comment_end_date,
+                comment_start_date = EXCLUDED.comment_start_date,
+                country = EXCLUDED.country,
+                docket_id = EXCLUDED.docket_id,
+                document_type = EXCLUDED.document_type,
+                effective_date = EXCLUDED.effective_date,
+                email = EXCLUDED.email,
+                fax = EXCLUDED.fax,
+                flex_field1 = EXCLUDED.flex_field1,
+                flex_field2 = EXCLUDED.flex_field2,
+                first_name = EXCLUDED.first_name,
+                submitter_gov_agency = EXCLUDED.submitter_gov_agency,
+                submitter_gov_agency_type = EXCLUDED.submitter_gov_agency_type,
+                implementation_date = EXCLUDED.implementation_date,
+                last_name = EXCLUDED.last_name,
+                modify_date = EXCLUDED.modify_date,
+                is_open_for_comment = EXCLUDED.is_open_for_comment,
+                submitter_org = EXCLUDED.submitter_org,
+                phone = EXCLUDED.phone,
+                posted_date = EXCLUDED.posted_date,
+                postmark_date = EXCLUDED.postmark_date,
+                reason_withdrawn = EXCLUDED.reason_withdrawn,
+                receive_date = EXCLUDED.receive_date,
+                reg_writer_instruction = EXCLUDED.reg_writer_instruction,
+                restriction_reason = EXCLUDED.restriction_reason,
+                restriction_reason_type = EXCLUDED.restriction_reason_type,
+                state_province_region = EXCLUDED.state_province_region,
+                subtype = EXCLUDED.subtype,
+                document_title = EXCLUDED.document_title,
+                topics = EXCLUDED.topics,
+                is_withdrawn = EXCLUDED.is_withdrawn,
+                postal_code = EXCLUDED.postal_code;
             """
             cursor.execute(insert_query, values)
             print(f"Document {document_id} inserted successfully.")


### PR DESCRIPTION
If a matching docket/document/comment ID is inserted into the respective SQL table, we will update the corresponding entry rather than throw an exception.