### PR TITLE
refactor ingest_comment for clarity

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -8,7 +8,7 @@ from .utils.ingest_opensearch import ingest_extracted_text_from_text as insert_e
 from .utils.ingest_summary import insert_summary
 
 
-def ingest_comment(contents):
+def ingest_comment_opensearch(contents):
     os = connect_opensearch()
     insert_comment_os(os,contents)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,4 +1,4 @@
-from .ingest import ingest_comment, ingest_docket, ingest_document
+from .ingest import ingest_comment_opensearch, ingest_docket, ingest_document
 
 def lambda_handler(event, context):
     docket = """
@@ -278,4 +278,4 @@ def lambda_handler(event, context):
 
     ingest_docket(docket)
     ingest_document(document)
-    ingest_comment(comment)
+    ingest_comment_opensearch(comment)


### PR DESCRIPTION
This PR changes ingest_comment from ingests.py to ingest_comment_opensearch, to not confuse with the other ingest_comment functions and with the sql ingest.