### PR TITLE
Added ingest scripts for abstracts and htm summary tables

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -6,6 +6,7 @@ from .utils.ingest_document import insert_document
 from .utils.ingest_opensearch import ingest_comment_from_text as insert_comment_os
 from .utils.ingest_opensearch import ingest_extracted_text_from_text as insert_extracted_text_os
 from .utils.ingest_summary import insert_summary
+from .utils.ingest_abstract import insert_abstract
 
 
 def ingest_comment(contents):
@@ -43,3 +44,8 @@ def ingest_summary(contents):
     sql.commit()
     sql.close()
 
+def ingest_abstract(contents):
+    sql = connect_sql()
+    insert_abstract(sql, contents)
+    sql.commit()
+    sql.close()

--- a/ingest.py
+++ b/ingest.py
@@ -35,6 +35,7 @@ def ingest_document(contents):
 def ingest_docket(contents):
     sql = connect_sql()
     insert_docket(sql, contents)
+    insert_abstract(sql, contents)
     sql.commit()
     sql.close()
 
@@ -44,8 +45,3 @@ def ingest_summary(contents):
     sql.commit()
     sql.close()
 
-def ingest_abstract(contents):
-    sql = connect_sql()
-    insert_abstract(sql, contents)
-    sql.commit()
-    sql.close()

--- a/utils/ingest_abstract.py
+++ b/utils/ingest_abstract.py
@@ -1,0 +1,31 @@
+import json
+import psycopg
+from dotenv import load_dotenv
+import sys
+import os
+from datetime import datetime
+
+
+# Function to insert docket abstract into the database
+def insert_abstract(conn, data):
+    docket_id = data["docket_id"]
+
+    # get the docket_abstract from the dockets table
+    try:
+        with conn.cursor() as cursor:
+            query = """
+            SELECT docket_abstract from dockets where docket_id = %s
+            """
+            cursor.execute(query, (docket_id,))
+            result = cursor.fetchone()
+
+            abstract = result[0]
+
+            insert_query = """
+            INSERT INTO abstracts (docket_id, abstract) VALUES (
+                %s, %s)
+            """
+            cursor.execute(insert_query, (docket_id, abstract))
+            print(f"Docket abstract for {docket_id} inserted successfully.")
+    except Exception as e:
+        print(f"An error occurred: {e}")

--- a/utils/ingest_abstract.py
+++ b/utils/ingest_abstract.py
@@ -7,25 +7,29 @@ from datetime import datetime
 
 
 # Function to insert docket abstract into the database
-def insert_abstract(conn, data):
-    docket_id = data["docket_id"]
+def insert_abstract(conn, json_data):
 
-    # get the docket_abstract from the dockets table
+   # Parse the JSON data
+    data = json.loads(json_data)
+
+    # Extract relevant fields
+    attributes = data["data"]["attributes"]
+    docket_id = data["data"]["id"]
+
+    # Prepare the values for insertion
+    values = (
+        docket_id,
+        attributes.get("dkAbstract")
+    )
+
+
     try:
         with conn.cursor() as cursor:
-            query = """
-            SELECT docket_abstract from dockets where docket_id = %s
-            """
-            cursor.execute(query, (docket_id,))
-            result = cursor.fetchone()
-
-            abstract = result[0]
-
             insert_query = """
             INSERT INTO abstracts (docket_id, abstract) VALUES (
                 %s, %s)
             """
-            cursor.execute(insert_query, (docket_id, abstract))
+            cursor.execute(insert_query, values)
             print(f"Docket abstract for {docket_id} inserted successfully.")
     except Exception as e:
         print(f"An error occurred: {e}")

--- a/utils/ingest_summary.py
+++ b/utils/ingest_summary.py
@@ -12,23 +12,13 @@ def insert_summary(conn, data):
     docket_id = data["docket_id"]
     summary_text = data["summary_text"]
 
-    # get the abstract from the dockets table
     try:
         with conn.cursor() as cursor:
-            query = """
-            SELECT docket_abstract from dockets where docket_id = %s
-            """
-            cursor.execute(query, (docket_id,))
-            result = cursor.fetchone()
-
-            abstract = result[0]
-
             insert_query = """
-            INSERT INTO summaries (docket_id, abstract, summary) VALUES (
-                %s, %s, %s
-            )
+            INSERT INTO htm_summaries (docket_id, summary) VALUES (
+                %s, %s)
             """
-            cursor.execute(insert_query, (docket_id, abstract, summary_text))
-            print(f"Docket summary and abstract for {docket_id} inserted successfully.")
+            cursor.execute(insert_query, (docket_id, summary_text))
+            print(f"Docket summary for {docket_id} inserted successfully.")
     except Exception as e:
         print(f"An error occurred: {e}")


### PR DESCRIPTION
- Added ingest scripts for new **htm_summary** and **abstracts** tables
- These replace the old ingest_summary as we created 2 new summary tables instead of the old combined one
- Each table has docket_id and respective summary